### PR TITLE
Ignore Player NPC's for WG Handlers where it doesn't make sense to apply them

### DIFF
--- a/src/main/java/net/goldtreeservers/worldguardextraflags/wg/handlers/CommandOnEntryFlagHandler.java
+++ b/src/main/java/net/goldtreeservers/worldguardextraflags/wg/handlers/CommandOnEntryFlagHandler.java
@@ -42,6 +42,12 @@ public class CommandOnEntryFlagHandler extends HandlerWrapper
 	@Override
 	public boolean onCrossBoundary(Player player, Location from, Location to, ApplicableRegionSet toSet, Set<ProtectedRegion> entered, Set<ProtectedRegion> exited, MoveType moveType)
 	{
+		// Ignore Player NPC's
+		if (player.hasMetadata("NPC"))
+		{
+			return true;
+		}
+
 		Collection<Set<String>> commands = WorldGuardUtils.queryAllValues(player, to.getWorld(), toSet.getRegions(), Flags.COMMAND_ON_ENTRY);
 
 		for(Set<String> commands_ : commands)

--- a/src/main/java/net/goldtreeservers/worldguardextraflags/wg/handlers/CommandOnExitFlagHandler.java
+++ b/src/main/java/net/goldtreeservers/worldguardextraflags/wg/handlers/CommandOnExitFlagHandler.java
@@ -48,6 +48,12 @@ public class CommandOnExitFlagHandler extends HandlerWrapper
 	@Override
 	public boolean onCrossBoundary(Player player, Location from, Location to, ApplicableRegionSet toSet, Set<ProtectedRegion> entered, Set<ProtectedRegion> exited, MoveType moveType)
 	{
+		// Ignore Player NPC's
+		if (player.hasMetadata("NPC"))
+		{
+			return true;
+		}
+
 		Collection<Set<String>> commands = new ArrayList<Set<String>>(WorldGuardUtils.queryAllValues(player, to.getWorld(), toSet.getRegions(), Flags.COMMAND_ON_EXIT));
 		
 		if (!commands.isEmpty())

--- a/src/main/java/net/goldtreeservers/worldguardextraflags/wg/handlers/ConsoleCommandOnEntryFlagHandler.java
+++ b/src/main/java/net/goldtreeservers/worldguardextraflags/wg/handlers/ConsoleCommandOnEntryFlagHandler.java
@@ -42,6 +42,12 @@ public class ConsoleCommandOnEntryFlagHandler extends HandlerWrapper
 	@Override
 	public boolean onCrossBoundary(Player player, Location from, Location to, ApplicableRegionSet toSet, Set<ProtectedRegion> entered, Set<ProtectedRegion> exited, MoveType moveType)
 	{
+		// Ignore Player NPC's
+		if (player.hasMetadata("NPC"))
+		{
+			return true;
+		}
+
 		Collection<Set<String>> commands = WorldGuardUtils.queryAllValues(player, to.getWorld(), toSet.getRegions(), Flags.CONSOLE_COMMAND_ON_ENTRY);
 
 		for(Set<String> commands_ : commands)

--- a/src/main/java/net/goldtreeservers/worldguardextraflags/wg/handlers/ConsoleCommandOnExitFlagHandler.java
+++ b/src/main/java/net/goldtreeservers/worldguardextraflags/wg/handlers/ConsoleCommandOnExitFlagHandler.java
@@ -48,6 +48,12 @@ public class ConsoleCommandOnExitFlagHandler extends HandlerWrapper
 	@Override
 	public boolean onCrossBoundary(Player player, Location from, Location to, ApplicableRegionSet toSet, Set<ProtectedRegion> entered, Set<ProtectedRegion> exited, MoveType moveType)
 	{
+		// Ignore Player NPC's
+		if (player.hasMetadata("NPC"))
+		{
+			return true;
+		}
+
 		Collection<Set<String>> commands = new ArrayList<Set<String>>(WorldGuardUtils.queryAllValues(player, to.getWorld(), toSet.getRegions(), Flags.CONSOLE_COMMAND_ON_EXIT));
 		
 		if (!commands.isEmpty())

--- a/src/main/java/net/goldtreeservers/worldguardextraflags/wg/handlers/PlaySoundsFlagHandler.java
+++ b/src/main/java/net/goldtreeservers/worldguardextraflags/wg/handlers/PlaySoundsFlagHandler.java
@@ -53,6 +53,12 @@ public class PlaySoundsFlagHandler extends HandlerWrapper
 	@Override
 	public boolean onCrossBoundary(Player player, Location from, Location to, ApplicableRegionSet toSet, Set<ProtectedRegion> entered, Set<ProtectedRegion> exited, MoveType moveType)
 	{
+		// Ignore Player NPC's
+		if (player.hasMetadata("NPC"))
+		{
+			return true;
+		}
+
 		this.check(player, toSet);
 		
 		return true;


### PR DESCRIPTION
# Overview
Player NPC's (as created by https://github.com/CitizensDev/Citizens2) trigger events that don't apply to non-players.

For example I have WG regions to provide an alertbar title of the area a player is in using the Console-Commands-On-Entry, and also change the game-mode of the player in the same way (As I've never managed to get WG gamemode region flag to work since 1.13). I also have a bunch of NPC's that wander around doing jobs and they trip these as well generating lots of console spam, especially as their names have spaces which mucks up the command.

This merely adds a check in some handlers for the NPC Metadata attribute and will short-circuit out of it exists.

# Closes
Closes #41