### PR TITLE
Fix stopSound

### DIFF
--- a/WG/src/main/java/net/goldtreeservers/worldguardextraflags/utils/SupportedFeatures.java
+++ b/WG/src/main/java/net/goldtreeservers/worldguardextraflags/utils/SupportedFeatures.java
@@ -1,8 +1,7 @@
 package net.goldtreeservers.worldguardextraflags.utils;
 
-import java.awt.Color;
-
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.potion.PotionEffect;
@@ -33,7 +32,7 @@ public class SupportedFeatures
 
 		try
 		{
-			SupportedFeatures.stopSoundSupported = Player.class.getDeclaredMethod("stopSound", Color.class) != null;
+			SupportedFeatures.stopSoundSupported = Player.class.getDeclaredMethod("stopSound", Sound.class) != null;
 		}
 		catch (Throwable ignored)
 		{


### PR DESCRIPTION
Fix the method signature used to detect whether stopSound is supported, thereby fixing sound stopping when leaving region.